### PR TITLE
Allow error overlay styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ __Note:__ This will only work if the element has an `id` attribute.
 
 A known issue is that Elm will clear out attributes for this root element, so `id="elm_root"` won't be visible after Elm loads.
 
+## Error overlay styling
+
+The error overlay comes with sensible default look, but allows style customization via CSS parts:
+
+```css
+elm-error-overlay {
+    position: relative;
+    z-index: 1000;
+}
+elm-error-overlay::part(background) {
+    background: red;
+    opacity: 0.7;
+}
+elm-error-overlay::part(parent) {
+    font-size: 16rem;
+}
+elm-error-overlay::part(error) {
+    opacity: 0.9;
+}
+```
+
 ## Known issues
 
 1. When in a React app, swapping a ".elm" component with a ".tsx" will causes issues with unmounting.

--- a/src/index.js
+++ b/src/index.js
@@ -681,8 +681,8 @@ if (import.meta.hot) {
             padding: 2em;
           }
         </style>
-        <div part="error-background" class="elm-error__background"></div>
-        <div part="error-parent" class="elm-error__parent">
+        <div part="background" class="elm-error__background"></div>
+        <div part="parent" class="elm-error__parent">
           <div part="error" class="elm-error"></div>
         </div>
       \`


### PR DESCRIPTION
While integrating this plugin into my project, I encountered a few problems with error overlay. They were caused by `rem` set explicitly to a lower-than-readable size in my app, which affected error overlay size and font-size. This made me want an option to customize error overlay styles.

Here I enable this via CSS-parts, which allow writing CSS selectors to target parts of custom-element inside of Shadow DOM.
