### PR TITLE
fix: long title or path in error object throws RangeError

### DIFF
--- a/src/elm-error-json.js
+++ b/src/elm-error-json.js
@@ -107,7 +107,7 @@ var header = function (error, problem, hasLinks) {
     let link = (label) => `<button data-source="${url}">${label}</button>`
     return PREFIX + left + ' ' + '-'.repeat(Math.max(5, dashCount(relativePath) - 5)) + ' ' + link(relativePath)
   } else {
-    return "".concat(PREFIX).concat(left, " ").concat(SPACER.repeat(dashCount(relativePath)), " ").concat(escapeHtml(relativePath))
+    return "".concat(PREFIX).concat(left, " ").concat(SPACER.repeat(Math.max(5, dashCount(relativePath))), " ").concat(escapeHtml(relativePath))
   }
 }
 var escapeHtml = function (str) {


### PR DESCRIPTION
Closes #16

Passing `Error`s with a `path` property that is too long to `toColoredHtmlOutput` or `toColoredTerminalOutput` throws a `RangeError` in `header`.

`header` attempts to use the `Error` object's `path` property to figure out how many dashes to put between the error title and the file path. If the length of the error title + the length of the file path + the prefix + `SPACING_COUNT` is greater than `MAX_WIDTH`, `dashCount` returns a negative value, and [`'-'.repeat`](https://github.com/ryan-haskell/vite-plugin-elm-watch/blob/54c2a228726257e76d191992efa4b5520f1dd0e0/src/elm-error-json.js#L108) and [`SPACER.repeat`](https://github.com/ryan-haskell/vite-plugin-elm-watch/blob/54c2a228726257e76d191992efa4b5520f1dd0e0/src/elm-error-json.js#L110) throws a `RangeError`.

Should probably just default to a `5` for `dashCount`, like the `link` branch defaults to `5`.

Example output from `elm-land generate` with an error in a file at the path `src/Pages/Utvalg/SelectionID_/EntryID_/Dokument/Base_/FormatOrId_/ALL_.elm`:

```text
RangeError: Invalid count value: -25
    at String.repeat (<anonymous>)
    at header (file:///home/gipphe/projects/test/node_modules/vite-plugin-elm-watch/src/elm-error-json.js:104:62)
    at toColoredTerminalOutput (file:///home/gipphe/projects/test/node_modules/vite-plugin-elm-watch/src/elm-error-json.js:160:30)
    at Array.map (<anonymous>)
    at generateElmFiles (file:///home/gipphe/projects/test/node_modules/elm-land/src/effects.js:354:16)
    at async generate (file:///home/gipphe/projects/ltest/node_modules/elm-land/src/effects.js:479:3)
    at async Object.run (file:///home/gipphe/projects/test/node_modules/elm-land/src/effects.js:685:22)
    at async main (file:///home/gipphe/projects/test/node_modules/elm-land/src/index.js:11:16)
```

Expected output from `elm-land generate` (by defaulting to `5` for `dashCount`):

```text
-- UNEXPECTED TYPE ANNOTATION ----- src/Pages/Utvalg/SelectionID_/EntryID_/Dokument/Base_/FormatOrId_/ALL_.elm

I found an unexpected type annotation on this page function.

  page : Auth.User -> Shared.Model -> Route Params -> Page Model Msg
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
I recommend one of these annotations:

  page : { selectionID : String, entryID : String, base : String, formatOrId : String, all_ : List String } -> View msg

  page : Page Model Msg

  page : Shared.Model -> Route { selectionID : String, entryID : String, base : String, formatOrId : String, all_ : List String } -> Page Model Msg

  page : Auth.User -> Shared.Model -> Route { selectionID : String, entryID : String, base : String, formatOrId : String, all_ : List String } -> Page Model Msg

Although Elm annotations are optional, Elm Land requires an annotation for
this particular function to avoid showing errors in generated code.

Hint: Read https://elm.land/problems#unexpected-type-annotation to learn more
```