### PR TITLE
Depend on elm instead of @lydell/elm (fix Elm 0.19.2 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ryannhg/vite-plugin-elm-watch#readme",
   "dependencies": {
-    "@lydell/elm": "0.19.1-14",
+    "elm": "0.19.2-0",
     "elm-watch-lib": "1.0.1",
     "cross-spawn": "7.0.6",
     "launch-editor": "2.10.0",


### PR DESCRIPTION
Fixes #18.

## Problem

The exact pin `@lydell/elm@0.19.1-14` in `dependencies` provides `node_modules/.bin/elm` as the **0.19.1** compiler. Since `elm-watch-lib` spawns `elm` through `PATH`, the compiler that actually runs is always 0.19.1 — so any project with `"elm-version": "0.19.2"` in its `elm.json` fails with `ELM VERSION MISMATCH` / `MODULE NOT FOUND`.

## Fix

Depend on `elm@0.19.2-0` directly instead of `@lydell/elm`.

As the `@lydell/elm` maintainer noted in #18, that package existed to ship a Linux ARM binary the official `elm` package lacked; the official `elm` now ships one, so `@lydell/elm` will not get 0.19.2 releases. Depending on `elm` directly is his first suggested fix.

`elm-watch-lib` pulls no elm binary of its own (its only deps are `cross-spawn` and `tiny-decoders`), so this direct dependency is the sole source of `.bin/elm` — swapping it is sufficient.

## Verification

Validated in a real project with `"elm-version": "0.19.2"`: with `overrides: { "@lydell/elm": "npm:elm@0.19.2-0" }` (equivalent to this change) `.bin/elm --version` returns `0.19.2` and Vite dev/build compile cleanly.

When 0.19.3 ships this pin will need bumping again; a future-proof range (or delegating the compiler to a user-installed `elm`, per #3) would avoid repeating it, but this unblocks 0.19.2 today with a one-line change.